### PR TITLE
On Demand Detection is using Composite Data Source

### DIFF
--- a/Monitor.TimedScript.PowerShell.FileAge.mpx
+++ b/Monitor.TimedScript.PowerShell.FileAge.mpx
@@ -336,12 +336,12 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`n Script Completed. `n Script Ru
 					<OnDemandDetections>
 						<OnDemandDetection MonitorTypeStateID="GoodCondition">
 							<Node ID="GoodConditionFilter">
-								<Node ID="DS" />
+								<Node ID="PA" />
 							</Node>
 						</OnDemandDetection>
 						<OnDemandDetection MonitorTypeStateID="BadCondition">
 							<Node ID="BadConditionFilter">
-								<Node ID="DS" />
+								<Node ID="PA" />
 							</Node>
 						</OnDemandDetection>
 					</OnDemandDetections>


### PR DESCRIPTION
HI Kevin

I think most of the PowerShell monitors that I've seen where you have created on demand detections are using the composite data source rather than the probe action.
- They are set to "DS"
- I believe they should be set to "PA"

With DS, they need to wait for the scheduler in the composite data source to execute. 